### PR TITLE
[FIX] tabIndex for blocked Navigation buttons

### DIFF
--- a/src/components/Navigation/NavigationButton.js
+++ b/src/components/Navigation/NavigationButton.js
@@ -29,7 +29,7 @@ const FlexLink = styled(Link)`
 
 function NavigationButton({ to, isActive, isBlocked, children }) {
   return (
-    <FlexLink data-testid="navigation-link" to={to} disabled={isBlocked}>
+    <FlexLink data-testid="navigation-link" to={to} disabled={isBlocked} tabIndex={isBlocked ? -1 : 0}>
       <LinkContent isActive={isActive} isBlocked={isBlocked}>
         {children}
       </LinkContent>

--- a/src/components/Navigation/__tests__/__snapshots__/Navigation.test.js.snap
+++ b/src/components/Navigation/__tests__/__snapshots__/Navigation.test.js.snap
@@ -129,6 +129,7 @@ exports[`COMPONENT - Navigation renders Navigation component with "Delivery" tab
     <Link
       className="c2"
       data-testid="navigation-link"
+      tabIndex={0}
       to="/checkout/delivery"
     >
       <span
@@ -146,6 +147,7 @@ exports[`COMPONENT - Navigation renders Navigation component with "Delivery" tab
       className="c5"
       data-testid="navigation-link"
       disabled={true}
+      tabIndex={-1}
       to="/checkout/payment"
     >
       <span
@@ -163,6 +165,7 @@ exports[`COMPONENT - Navigation renders Navigation component with "Delivery" tab
       className="c5"
       data-testid="navigation-link"
       disabled={true}
+      tabIndex={-1}
       to="/checkout/review"
     >
       <span
@@ -329,6 +332,7 @@ exports[`COMPONENT - Navigation renders Navigation component with "Payment" tab 
     <Link
       className="c2"
       data-testid="navigation-link"
+      tabIndex={0}
       to="/checkout/delivery"
     >
       <span
@@ -346,6 +350,7 @@ exports[`COMPONENT - Navigation renders Navigation component with "Payment" tab 
       className="c2"
       data-testid="navigation-link"
       disabled={false}
+      tabIndex={0}
       to="/checkout/payment"
     >
       <span
@@ -363,6 +368,7 @@ exports[`COMPONENT - Navigation renders Navigation component with "Payment" tab 
       className="c6"
       data-testid="navigation-link"
       disabled={true}
+      tabIndex={-1}
       to="/checkout/review"
     >
       <span
@@ -483,6 +489,7 @@ exports[`COMPONENT - Navigation renders Navigation component with "Review" tab s
     <Link
       className="c2"
       data-testid="navigation-link"
+      tabIndex={0}
       to="/checkout/delivery"
     >
       <span
@@ -500,6 +507,7 @@ exports[`COMPONENT - Navigation renders Navigation component with "Review" tab s
       className="c2"
       data-testid="navigation-link"
       disabled={false}
+      tabIndex={0}
       to="/checkout/payment"
     >
       <span
@@ -517,6 +525,7 @@ exports[`COMPONENT - Navigation renders Navigation component with "Review" tab s
       className="c2"
       data-testid="navigation-link"
       disabled={false}
+      tabIndex={0}
       to="/checkout/review"
     >
       <span


### PR DESCRIPTION
Sets blocked NavigationButton to be unreachable via sequential keyboard navigation.